### PR TITLE
build updated

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,6 +36,8 @@ jobs:
 
     permissions:
       id-token: write  # Required for OIDC Trusted Publishing to npm
+      contents: write  # Required for creating git tags and releases
+      packages: write  # Required for publishing to GitHub Packages
     
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary by Sourcery

Update CI build-and-publish workflow permissions to support tagging, releases, and GitHub Packages publishing.

CI:
- Grant workflow permission to write repository contents for creating git tags and releases.
- Grant workflow permission to write packages for publishing to GitHub Packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to support automated release creation and package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->