### PR TITLE
v1.0.4

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -36,6 +36,8 @@ jobs:
 
     permissions:
       id-token: write  # Required for OIDC Trusted Publishing to npm
+      contents: write  # Required for creating git tags and releases
+      packages: write  # Required for publishing to GitHub Packages
     
     outputs:
       version: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions build-and-publish workflow permissions for publishing and tagging.

Build:
- Grant workflow permissions to write repository contents for creating tags and releases.
- Grant workflow permissions to write packages for publishing to GitHub Packages.