### PR TITLE
fix(cli): recursive nested discovery on Windows + CSX encoding handling

### DIFF
--- a/src/commands/reset.js
+++ b/src/commands/reset.js
@@ -4,7 +4,7 @@ const inquirer = require('inquirer');
 const path = require('path');
 const { glob } = require('glob');
 const config = require('../lib/config');
-const { discoverComponents } = require('../lib/discover');
+const { discoverComponents, toGlobPattern } = require('../lib/discover');
 const { getDomain, getComponentTypes } = require('../lib/vnextConfig');
 const { getJsonMetadata, findAllJson, detectComponentType } = require('../lib/workflow');
 const { publishComponent, reinitializeSystem } = require('../lib/api');
@@ -93,7 +93,7 @@ async function resetCommand(options) {
     }
     
     // Find JSONs in this folder only
-    const pattern = path.join(dir, '**/*.json');
+    const pattern = toGlobPattern(dir, '**/*.json');
     const files = await glob(pattern, {
       ignore: [
         '**/.meta/**',

--- a/src/lib/csx.js
+++ b/src/lib/csx.js
@@ -93,7 +93,8 @@ function getCsxLocation(csxPath, projectRoot) {
 /**
  * Updates ALL CSX codes in a JSON file
  * Updates all references with the same location
- * Supports encoding types: NAT (native/plain text), B64 (Base64, default)
+ * Encoding handling: absent/B64 -> Base64 (default), NAT -> native source as
+ * an escaped JSON string, any other value (e.g. REF) -> left untouched
  * @param {string} jsonPath - JSON file path
  * @param {string} csxLocation - CSX location path
  * @param {string} base64Code - Base64 encoded CSX content
@@ -122,17 +123,22 @@ async function updateCodeInJson(jsonPath, csxLocation, base64Code, nativeCode) {
     }
     
     if (obj.location === csxLocation && 'code' in obj) {
-      // Check encoding type: NAT = Native (plain text), B64 or empty = Base64 (default)
+      // Encoding decides how the CSX content is embedded:
+      //   absent / B64 -> Base64 (default)
+      //   NAT          -> JSON-stringified native source
+      //   anything else (e.g. REF) -> leave untouched
       const encoding = obj.encoding ? obj.encoding.toUpperCase() : 'B64';
-      
-      if (encoding === 'NAT') {
-        // Native encoding - write plain text content
-        obj.code = nativeCode;
-      } else {
-        // B64 or default - write Base64 encoded content
+
+      if (encoding === 'B64') {
         obj.code = base64Code;
+        updateCount++;
+      } else if (encoding === 'NAT') {
+        // Native source as-is; JSON.stringify of the whole document escapes
+        // newlines/quotes so the stored value becomes a normal JSON string.
+        obj.code = nativeCode;
+        updateCount++;
       }
-      updateCount++;
+      // Other encodings (e.g. REF) are intentionally skipped — no modification.
     }
     
     // Scan all elements in array or object

--- a/src/lib/discover.js
+++ b/src/lib/discover.js
@@ -4,6 +4,19 @@ const fs = require('fs');
 const { getComponentsRoot, getComponentTypes } = require('./vnextConfig');
 
 /**
+ * Builds a glob pattern with forward slashes.
+ * glob treats backslashes as escape characters, so on Windows a pattern built
+ * with path.join (which uses "\") breaks "**" recursion and nested files are
+ * never matched. Always feed glob forward-slash separators.
+ * @param {string} dir - Base directory
+ * @param {string} suffix - Glob suffix, e.g. "**\/*.json"
+ * @returns {string} Forward-slash glob pattern
+ */
+function toGlobPattern(dir, suffix) {
+  return path.join(dir, suffix).split(path.sep).join('/');
+}
+
+/**
  * Discovers component folders based on vnext.config.json paths
  * Only scans folders defined in paths, ignores everything else
  * @param {string} projectRoot - Project root folder (PROJECT_ROOT)
@@ -35,8 +48,8 @@ async function discoverComponents(projectRoot) {
  * @returns {Promise<string[]>} JSON file paths
  */
 async function findJsonInComponent(componentDir) {
-  const pattern = path.join(componentDir, '**/*.json');
-  
+  const pattern = toGlobPattern(componentDir, '**/*.json');
+
   const files = await glob(pattern, {
     ignore: [
       '**/.meta/**',
@@ -90,7 +103,7 @@ async function findAllCsxInComponents(projectRoot) {
   // Only scan folders that were discovered from paths
   for (const [type, componentDir] of Object.entries(discovered)) {
     if (componentDir) {
-      const pattern = path.join(componentDir, '**/*.csx');
+      const pattern = toGlobPattern(componentDir, '**/*.csx');
       const files = await glob(pattern, {
         ignore: [
           '**/.meta/**',
@@ -157,6 +170,7 @@ function detectComponentTypeFromPath(filePath, componentTypes) {
 }
 
 module.exports = {
+  toGlobPattern,
   discoverComponents,
   findJsonInComponent,
   findAllJsonFiles,

--- a/src/lib/workflow.js
+++ b/src/lib/workflow.js
@@ -4,7 +4,7 @@ const { glob } = require('glob');
 const { publishComponent } = require('./api');
 const { getInstanceId, deleteWorkflow } = require('./db');
 const { getComponentTypes } = require('./vnextConfig');
-const { discoverComponents, findJsonInComponent } = require('./discover');
+const { discoverComponents, findJsonInComponent, toGlobPattern } = require('./discover');
 
 /**
  * Gets key and version values from JSON file
@@ -167,7 +167,7 @@ async function getGitChangedJson(projectRoot) {
  * @returns {Promise<string[]>} JSON file paths
  */
 async function findAllJsonInComponent(componentDir) {
-  const pattern = path.join(componentDir, '**/*.json');
+  const pattern = toGlobPattern(componentDir, '**/*.json');
   const files = await glob(pattern, {
     ignore: [
       '**/.meta/**',


### PR DESCRIPTION
Closes #36

## What changed

### 1. Nested flow discovery on Windows (#36)
Component discovery built glob patterns with `path.join(dir, '**/*.json')`. On Windows `path.join` emits `\` separators, and glob treats backslashes as **escape characters** — so the `**` segment broke and flows nested in subdirectories (e.g. `Workflows/security-check/sub-domain/x.json`) were never matched.

- Added `toGlobPattern(dir, suffix)` in `src/lib/discover.js` that always emits forward-slash patterns.
- Routed all four glob-pattern builders through it: `findJsonInComponent` & `findAllCsxInComponents` (`discover.js`), `findAllJsonInComponent` (`workflow.js`), and the `reset` command (`reset.js`).

### 2. CSX `encoding` handling (`updateCodeInJson`)
Refined how embedded CSX code is written based on the per-reference `encoding` field:

| `encoding` | Behavior |
|------------|----------|
| absent / `B64` | Base64 (default, unchanged) |
| `NAT` | native source written as-is → stored as an escaped JSON string (e.g. `"using ...;\n\n..."`) |
| any other value (e.g. `REF`) | **left untouched** |

Previously any non-`NAT` value (including `REF`) was overwritten with Base64; `REF` and unknown encodings are now skipped entirely.

## Why
- macOS/Linux already discovered nested flows correctly; the discovery gap was Windows-specific (the project targets Windows users via the `vnext` alias). Confirmed locally: a backslash glob pattern matches 0 files, the forward-slash equivalent matches all.
- The vNext schema introduced `encoding: "REF"` (and may add others); the CLI must not clobber the `code` of references it doesn't own.

## Reviewer notes
- `NAT` output deliberately stores the raw source string and lets the document serialization escape newlines/quotes — no double-encoding. Verified the output matches the expected `"code": "using Newtonsoft.Json;\n\n..."` form.
- No code changes were needed in `check`/`sync` — they were already config-driven and use the now-fixed discovery helpers.

## Verification
- `findJsonInComponent` finds depth-3 nested JSON; `toGlobPattern` always returns forward slashes.
- CSX encoding matrix tested: absent→B64, B64→B64, NAT→escaped native string, REF→untouched, unknown→untouched.
- All command/lib modules load without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Windows glob-based discovery of nested workflow files and refine CSX encoding-aware code updates.

Bug Fixes:
- Ensure JSON and CSX discovery uses forward-slash glob patterns so nested files are correctly found on Windows.
- Prevent CSX references with non-B64, non-NAT encodings (e.g. REF) from having their code field unintentionally overwritten.

Enhancements:
- Clarify CSX encoding behavior documentation and support NAT encoding by storing native source as a normal JSON string.