### PR TITLE
fix(csx): embed CSX into references that only declare a location

### DIFF
--- a/src/lib/csx.js
+++ b/src/lib/csx.js
@@ -122,8 +122,9 @@ async function updateCodeInJson(jsonPath, csxLocation, base64Code, nativeCode) {
       return;
     }
     
-    if (obj.location === csxLocation && 'code' in obj) {
-      // Encoding decides how the CSX content is embedded:
+    if (obj.location === csxLocation) {
+      // A reference may carry only `location` — the `code` key is then created
+      // here. Encoding decides how the CSX content is embedded:
       //   absent / B64 -> Base64 (default)
       //   NAT          -> JSON-stringified native source
       //   anything else (e.g. REF) -> leave untouched


### PR DESCRIPTION
## Problem

A script reference that declares only a `location` was silently ignored by the `csx` embedding step:

```json
"rule": {
  "location": "./src/NsAllSubsDoneRule.csx"
},
"mapping": {
  "location": "./src/NsNotifySpawnMapping.csx"
}
```

No `code` field was ever written for these, so the documented default (absent `encoding` → Base64) never took effect.

## Root cause

`updateCodeInJson` in `src/lib/csx.js` matched references with:

```js
if (obj.location === csxLocation && 'code' in obj) {
```

The `'code' in obj` guard meant the encoding logic just below it was unreachable whenever the `code` key was absent. In practice the default-B64 behaviour only applied to references that already had a `code` field written into them at some earlier point — a chicken-and-egg situation for any newly authored component.

The guard dates back to the initial commit (`4aa0f78`); it was not introduced by the recent CSX encoding work.

## Fix

Drop the guard so the `code` key is created when missing. Encoding handling is unchanged.

## Behaviour after the change

| Reference shape | Result |
|---|---|
| `location` only | `code` created, Base64 (default) |
| `location` + existing `code` | overwritten (no regression) |
| `encoding: "NAT"` | native source written as plain text |
| `encoding: "REF"` | untouched — no `code` key added |

## Verification

This repo has no test suite, so verification was done by running the CLI against a purpose-built vNext workspace containing all four reference shapes above in one component.

Before the fix:

```
NsNotifySpawnMapping.csx -> "No references to update", totalUpdates: 0
NsAllSubsDoneRule.csx    -> totalUpdates: 1   // only the ref that already had `code`
```

After the fix, via `wf csx --all`:

```
[CSX] ✓ NsNotifySpawnMapping.csx → 1 JSON, 2 refs
[CSX] ✓ NsAllSubsDoneRule.csx → 1 JSON, 2 refs
```

All four shapes produced the expected output, and the `REF` reference correctly gained no `code` key.

## Reviewer notes

- Match is exact string equality against the CSX file's own derived location, so removing the guard cannot make an unrelated object gain a `code` key.
- The `REF` case is protected by the `encoding` check further down, not by the removed guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix CSX embedding to populate the code field for references that only specify a location without an existing code key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matching references are now updated correctly even when they do not already have a code value.
  * Newly assigned code values are generated according to the reference’s encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->